### PR TITLE
Use uniqid() to avoid collisions

### DIFF
--- a/src/PathPreserver.php
+++ b/src/PathPreserver.php
@@ -99,7 +99,7 @@ class PathPreserver
                 continue;
             }
 
-            $unique = $installPath.' '.time();
+            $unique = $installPath.' '.uniqid('', true);
             $cacheRoot = $this->filesystem->normalizePath($this->cacheDir.'/preserve-paths/'.sha1($unique));
             $this->filesystem->ensureDirectoryExists($cacheRoot);
 


### PR DESCRIPTION
We use this plugin in projects which are tested via Gitlab CI.  Some of these projects test multiple versions of PHP simultaneously. To achieve better performance and keep bandwidth usage low, our runners use a shared Composer cache.

It's extremely likely we'll have two `composer install` commands start (and be running) at the same second with the same `composer.json` contents.  As a result, the "unique" path used by the plugin ends up being the same in both runners.  This leads to situations where one job is adding/deleting files and folders currently being used by the other one, causing it to fail.

I therefore propose using a different method to generate a unique path which is not based on the time in seconds.  ~~`random_bytes()`~~ `uniqid('', true)` seems to fit this need nicely.