### PR TITLE
Make it possible to set preserve-paths in dependency extras.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Simply install the plugin with composer: `composer require drupal-composer/prese
 
 ## Configuration
 
-For configuring the paths you need to set `preserve-paths` within the `extra` of your root `composer.json`.
+For configuring the paths you need to set `preserve-paths` within the `extra` of your `composer.json`.
 
 ```json
 {
@@ -30,6 +30,24 @@ For configuring the paths you need to set `preserve-paths` within the `extra` of
       }
 }
 ```
+
+In case you need to set the `preserve-paths` option in a dependent package, you must also set `preserve-paths-as-dependency` in the `composer.json` of the dependency.
+
+```json
+{
+    "extra": {
+        "preserve-paths-as-dependency": true,
+        "preserve-paths": [
+          "web/sites/all/modules/contrib",
+          "web/sites/all/themes/contrib",
+          "web/sites/all/libraries",
+          "web/sites/all/drush"
+        ]
+      }
+}
+```
+
+You can disable this setting in your root `composer.json` by setting `preserve-paths-ignore-dependencies` to true.
 
 ## Example
 


### PR DESCRIPTION
**Issue**:
I use a CMS which uses composer for extension management. In this implementation sometimes only the package name is known. Therefore the installed package is always wrapped in a new root package which has the package to install as dependency. Unfortunately this root package has none of the `extra` my package has and I can not change it. Therefore I can not use this plugin at the moment.

**Solution**:
Make it possible to get the preserve paths from the dependencies. To ensure that this causes no new issues, I added two new options. A package has to declare that his preserve paths should be read if it is used as dependency (`preserve-paths-as-dependency`). Additionally anyone who uses your plugin can override this behavior in your root package by setting `preserve-paths-ignore-dependencies` to true. In this case no information will be read for any of the dependencies.

I would be glad if you could include this, but it would also be ok for me if you decide that this is too specific and you do not want to have this change.