### PR TITLE
Fix Null Path error on composer install.

### DIFF
--- a/src/PluginWrapper.php
+++ b/src/PluginWrapper.php
@@ -187,6 +187,9 @@ class PluginWrapper
     {
         $return = array();
         foreach ($paths as $path) {
+            if (empty($path)) {
+                continue;
+            }
             if (!$this->filesystem->isAbsolutePath($path)) {
                 $path = getcwd().'/'.$path;
             }


### PR DESCRIPTION
Solution originally found in this issue: https://github.com/drupal-composer/preserve-paths/issues/43.